### PR TITLE
Make admonition fails in latest Sphinx build

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,7 @@ if [ -n "$WERCKER_SPHINX_BASEDIR" ]; then
 fi
 
 info "Installing Sphinx and other packages."
-pip install --upgrade -e git+https://github.com/sphinx-doc/sphinx@stable#egg=sphinx-stable $WERCKER_SPHINX_PACKAGES
+pip install --upgrade -e git+https://github.com/sphinx-doc/sphinx@1.5.5#egg=sphinx-1_5_5 $WERCKER_SPHINX_PACKAGES
 
 if [ -e "requirements.txt" ]; then
   info "Installing required packages."

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: sphinx
-version: 0.2.1
+version: 0.2.3
 description: |
     Run Sphinx (http://www.sphinx-doc.org/en/stable/) to generate a documents.
 type: build


### PR DESCRIPTION
Hi, I ran into problems on Wercker with:

Could not import extension sphinxcontrib.fancybox (exception: cannot import name 'make_admonition')

Found a few people with this issue with Sphinx, and that 1.5.5 works okay:

https://github.com/wxWidgets/Phoenix/issues/458

So set the version to 1.5.5 instead of stable and it seems to work again. Not sure if Sphinx has a fix coming up.